### PR TITLE
fix: build histogram x-axis as intervals (a, b] (#4)

### DIFF
--- a/bvmlib/bvm.py
+++ b/bvmlib/bvm.py
@@ -186,8 +186,8 @@ class BVM():
 
         if self.sensitive_attributes is not None:
             class_size = sum(variables['sensitive_values'][self.sensitive_attributes[0]].values())
-            bin_interval_rhs = math.ceil(100 * 1 / class_size)
-            bin_interval = (bin_interval_rhs - 1, bin_interval_rhs)
+            bin_endpoint = math.ceil(100 * 1 / class_size)
+            bin_interval = f"({bin_endpoint - 1}, {bin_endpoint}]"
             variables['bins']['re_id'][bin_interval] += class_size
 
             for attribute in self.sensitive_attributes:
@@ -208,8 +208,8 @@ class BVM():
                     print("class_size (=" + str(class_size) + ") and counts (=" + str(sum(counts)) + ") error!\n" +
                           "QID: " + str(self.quasi_identifiers) + ". Sensitive attribute: " + attribute + ".")
 
-                bin_interval_rhs = math.ceil(100 * max_value / class_size)
-                bin_interval = (bin_interval_rhs - 1, bin_interval_rhs)
+                bin_endpoint = math.ceil(100 * max_value / class_size)
+                bin_interval = f"({bin_endpoint - 1}, {bin_endpoint}]"
                 variables['bins'][attribute][bin_interval] += class_size
 
                 variables['CA'][attribute].update(p = variables['CA'][attribute]['p'] + max_value)
@@ -226,8 +226,8 @@ class BVM():
                 variables['sensitive_values'][attribute].clear()
         else:
             class_size = eq_class_size
-            bin_interval_rhs = math.ceil(100 * 1 / class_size)
-            bin_interval = (bin_interval_rhs - 1, bin_interval_rhs)
+            bin_endpoint = math.ceil(100 * 1 / class_size)
+            bin_interval = f"({bin_endpoint - 1}, {bin_endpoint}]"
             variables['bins']['re_id'][bin_interval] += class_size
             if class_size == 1:
                 class_size_one = True
@@ -383,7 +383,7 @@ class BVM():
         "bins --> {'re_id':{'0%':a,'1%':b,'2%':c,...,'100%':d},'attr_1':{'0%':e,...,'100%':f},}"
         "bins: 'x%' for chance of re-identification or attribute-inference, y% for amount of rows with 'x%' chance."
         bins = {}
-        bins['re_id'] = {(i, i + 1): 0 for i in range(100)}
+        bins['re_id'] = {f"({i}, {i + 1}]": 0 for i in range(100)}
 
         "attributes --> self.quasi_identifiers"
         "attributes --> self.quasi_identifiers + self.sensitive_attributes"
@@ -403,7 +403,7 @@ class BVM():
             for attribute in self.sensitive_attributes:
                 sensitive_values[attribute] = {}
                 CA[attribute] = {'d': 0,'p': 0}
-                bins[attribute] = {(i, i + 1): 0 for i in range(100)}
+                bins[attribute] = {f"({i}, {i + 1}]": 0 for i in range(100)}
                 attributes.append(attribute)
 
             if self.worth_assignment is not None:

--- a/examples/single-dataset.ipynb
+++ b/examples/single-dataset.ipynb
@@ -12,11 +12,18 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "8b643027",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "import pandas\n",
-    "from bvmlib.bvm import BVM"
+    "import sys\n",
+    "\n",
+    "sys.path.append(\"../\")\n",
+    "from bvmlib.bvm import BVM\n",
+    "\n",
+    "from ucimlrepo import fetch_ucirepo "
    ]
   },
   {
@@ -258,7 +265,7 @@
        "      <td>5</td>\n",
        "      <td>0.1</td>\n",
        "      <td>0.5</td>\n",
-       "      <td>{'0': 0.0, '1': 0.0, '2': 0.0, '3': 0.0, '4': ...</td>\n",
+       "      <td>{'(0, 1]': 0.0, '(1, 2]': 0.0, '(2, 3]': 0.0, ...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -269,7 +276,7 @@
        "0  ['age', 'gender']  0.2   5    0.1        0.5   \n",
        "\n",
        "                                           Histogram  \n",
-       "0  {'0': 0.0, '1': 0.0, '2': 0.0, '3': 0.0, '4': ...  "
+       "0  {'(0, 1]': 0.0, '(1, 2]': 0.0, '(2, 3]': 0.0, ...  "
       ]
      },
      "metadata": {},
@@ -314,7 +321,7 @@
        "      <td>2.666667</td>\n",
        "      <td>0.3</td>\n",
        "      <td>0.8</td>\n",
-       "      <td>{'0': 0.0, '1': 0.0, '2': 0.0, '3': 0.0, '4': ...</td>\n",
+       "      <td>{'(0, 1]': 0.0, '(1, 2]': 0.0, '(2, 3]': 0.0, ...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -324,7 +331,7 @@
        "      <td>1.400000</td>\n",
        "      <td>0.5</td>\n",
        "      <td>0.7</td>\n",
-       "      <td>{'0': 0.0, '1': 0.0, '2': 0.0, '3': 0.0, '4': ...</td>\n",
+       "      <td>{'(0, 1]': 0.0, '(1, 2]': 0.0, '(2, 3]': 0.0, ...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -336,8 +343,8 @@
        "1  ['age', 'gender']  disability  0.2  1.400000    0.5        0.7   \n",
        "\n",
        "                                           Histogram  \n",
-       "0  {'0': 0.0, '1': 0.0, '2': 0.0, '3': 0.0, '4': ...  \n",
-       "1  {'0': 0.0, '1': 0.0, '2': 0.0, '3': 0.0, '4': ...  "
+       "0  {'(0, 1]': 0.0, '(1, 2]': 0.0, '(2, 3]': 0.0, ...  \n",
+       "1  {'(0, 1]': 0.0, '(1, 2]': 0.0, '(2, 3]': 0.0, ...  "
       ]
      },
      "metadata": {},
@@ -747,7 +754,7 @@
        "      <td>12649</td>\n",
        "      <td>0.000031</td>\n",
        "      <td>0.388471</td>\n",
-       "      <td>{'0': 0.0, '1': 0.009182764657105125, '2': 0.0...</td>\n",
+       "      <td>{'(0, 1]': 0.0, '(1, 2]': 0.04708086360983999,...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -758,7 +765,7 @@
        "0  ['age', 'sex', 'race', 'native-country', 'mari...  0.262738  12649   \n",
        "\n",
        "      Prior  Posterior                                          Histogram  \n",
-       "0  0.000031   0.388471  {'0': 0.0, '1': 0.009182764657105125, '2': 0.0...  "
+       "0  0.000031   0.388471  {'(0, 1]': 0.0, '(1, 2]': 0.04708086360983999,...  "
       ]
      },
      "metadata": {},
@@ -803,7 +810,7 @@
        "      <td>2.176685</td>\n",
        "      <td>0.405178</td>\n",
        "      <td>0.881945</td>\n",
-       "      <td>{'0': 0.0, '1': 0.0, '2': 0.0, '3': 0.0, '4': ...</td>\n",
+       "      <td>{'(0, 1]': 0.0, '(1, 2]': 0.0, '(2, 3]': 0.0, ...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -813,7 +820,7 @@
        "      <td>2.008571</td>\n",
        "      <td>0.322502</td>\n",
        "      <td>0.647769</td>\n",
-       "      <td>{'0': 0.0, '1': 0.0, '2': 0.0, '3': 0.0, '4': ...</td>\n",
+       "      <td>{'(0, 1]': 0.0, '(1, 2]': 0.0, '(2, 3]': 0.0, ...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -829,8 +836,8 @@
        "1  2.008571  0.322502   0.647769   \n",
        "\n",
        "                                           Histogram  \n",
-       "0  {'0': 0.0, '1': 0.0, '2': 0.0, '3': 0.0, '4': ...  \n",
-       "1  {'0': 0.0, '1': 0.0, '2': 0.0, '3': 0.0, '4': ...  "
+       "0  {'(0, 1]': 0.0, '(1, 2]': 0.0, '(2, 3]': 0.0, ...  \n",
+       "1  {'(0, 1]': 0.0, '(1, 2]': 0.0, '(2, 3]': 0.0, ...  "
       ]
      },
      "metadata": {},
@@ -904,28 +911,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 24,
    "id": "be2b57bb",
    "metadata": {},
    "outputs": [],
    "source": [
     "def load2():\n",
-    "    header = ['caseid', 'dAge', 'dAncstry1', 'dAncstry2', 'iAvail', 'iCitizen', 'iClass', 'dDepart', 'iDisabl1',\n",
-    "              'iDisabl2', 'iEnglish', 'iFeb55', 'iFertil', 'dHispanic', 'dHour89', 'dHours', 'iImmigr', 'dIncome1',\n",
-    "              'dIncome2', 'dIncome3', 'dIncome4', 'dIncome5', 'dIncome6', 'dIncome7', 'dIncome8', 'dIndustry',\n",
-    "              'iKorean', 'iLang1', 'iLooking', 'iMarital', 'iMay75880', 'iMeans', 'iMilitary', 'iMobility',\n",
-    "              'iMobillim', 'dOccup', 'iOthrserv', 'iPerscare', 'dPOB', 'dPoverty', 'dPwgt1', 'iRagechld',\n",
-    "              'dRearning', 'iRelat1', 'iRelat2', 'iRemplpar', 'iRiders', 'iRlabor', 'iRownchld', 'dRpincome',\n",
-    "              'iRPOB', 'iRrelchld', 'iRspouse', 'iRvetserv', 'iSchool', 'iSept80', 'iSex', 'iSubfam1', 'iSubfam2',\n",
-    "              'iTmpabsnt', 'dTravtime', 'iVietnam', 'dWeek89', 'iWork89', 'iWorklwk', 'iWWII', 'iYearsch',\n",
-    "              'iYearwrk', 'dYrsserv']\n",
     "    attributes = ['dAge', 'dAncstry1', 'dAncstry2', 'iCitizen', 'iClass', 'iDisabl1', 'iDisabl2', 'iEnglish',\n",
     "                  'iFertil', 'dHour89', 'iImmigr', 'dIncome1', 'dIncome2', 'dIncome3', 'dIncome4', 'dIncome5',\n",
     "                  'dIncome6', 'dIncome7', 'dIncome8', 'dIndustry', 'iKorean', 'iLang1', 'iMarital', 'iMeans',\n",
     "                  'dOccup', 'dPOB', 'dPoverty', 'iRagechld', 'dRearning', 'iSchool', 'iSex',\n",
     "                  'iVietnam', 'iWWII', 'iYearsch']\n",
-    "    source = 'https://archive.ics.uci.edu/ml/machine-learning-databases/census1990-mld/USCensus1990.data.txt'\n",
-    "    df = pandas.read_csv(source, usecols=attributes, low_memory=False)\n",
+    "    df = fetch_ucirepo(id=116).data.features[attributes]\n",
     "    return df"
    ]
   },
@@ -973,7 +970,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 25,
    "id": "cc540c96",
    "metadata": {},
    "outputs": [
@@ -1345,7 +1342,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 26,
    "id": "1f35a440",
    "metadata": {},
    "outputs": [],
@@ -1381,7 +1378,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 27,
    "id": "c7e2bd13",
    "metadata": {},
    "outputs": [],
@@ -1392,7 +1389,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 28,
    "id": "5be8b0c4",
    "metadata": {},
    "outputs": [],
@@ -1402,7 +1399,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 29,
    "id": "13597472",
    "metadata": {},
    "outputs": [
@@ -1443,7 +1440,7 @@
        "      <td>252597</td>\n",
        "      <td>4.067877e-07</td>\n",
        "      <td>0.102753</td>\n",
-       "      <td>{'0': 0.560129927978245, '1': 0.11174660383153...</td>\n",
+       "      <td>{'(0, 1]': 0.634853973400155, '(1, 2]': 0.0639...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1454,7 +1451,7 @@
        "0  ['dAge', 'dAncstry1', 'dAncstry2', 'iClass', '...  0.06383  252597   \n",
        "\n",
        "          Prior  Posterior                                          Histogram  \n",
-       "0  4.067877e-07   0.102753  {'0': 0.560129927978245, '1': 0.11174660383153...  "
+       "0  4.067877e-07   0.102753  {'(0, 1]': 0.634853973400155, '(1, 2]': 0.0639...  "
       ]
      },
      "metadata": {},
@@ -1499,7 +1496,7 @@
        "      <td>1.079108</td>\n",
        "      <td>0.913132</td>\n",
        "      <td>0.985367</td>\n",
-       "      <td>{'0': 0.0, '1': 0.0, '2': 0.0, '3': 0.0, '4': ...</td>\n",
+       "      <td>{'(0, 1]': 0.0, '(1, 2]': 0.0, '(2, 3]': 0.0, ...</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -1509,7 +1506,7 @@
        "      <td>1.764960</td>\n",
        "      <td>0.470504</td>\n",
        "      <td>0.830422</td>\n",
-       "      <td>{'0': 0.0, '1': 0.0, '2': 0.0, '3': 0.0, '4': ...</td>\n",
+       "      <td>{'(0, 1]': 0.0, '(1, 2]': 0.0, '(2, 3]': 0.0, ...</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1525,8 +1522,8 @@
        "1  1.764960  0.470504   0.830422   \n",
        "\n",
        "                                           Histogram  \n",
-       "0  {'0': 0.0, '1': 0.0, '2': 0.0, '3': 0.0, '4': ...  \n",
-       "1  {'0': 0.0, '1': 0.0, '2': 0.0, '3': 0.0, '4': ...  "
+       "0  {'(0, 1]': 0.0, '(1, 2]': 0.0, '(2, 3]': 0.0, ...  \n",
+       "1  {'(0, 1]': 0.0, '(1, 2]': 0.0, '(2, 3]': 0.0, ...  "
       ]
      },
      "metadata": {},
@@ -1610,7 +1607,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1624,7 +1621,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.14"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
Closes #4 

This PR changes the way histograms are constructed by (i) using intervals as labels for the keys and (ii) using ceil instead of rounding to compute the bins. By using ceil, all values are transformed into the endpoint of the corresponding interval, so reconstructing the interval becomes trivial.